### PR TITLE
PHP 4 style constructors deprecated in PHP 7.0.x

### DIFF
--- a/HTML/Template/PHPLIB.php
+++ b/HTML/Template/PHPLIB.php
@@ -4,7 +4,7 @@
  * is copyright by Kristian Koehntopp, NetUSE AG and was released
  * under the LGPL.
  *
- * PHP Versions 4 and 5
+ * PHP Versions 4.x/5.x/7.0.x
  *
  * @category HTML
  * @package  HTML_Template_PHPLIB
@@ -114,7 +114,7 @@ class HTML_Template_PHPLIB
      *
      * @access public
      */
-    function HTML_Template_PHPLIB(
+    function __construct(
         $root = '.', $unknowns = 'remove', $fallback=''
     ) {
         $this->setRoot($root);

--- a/HTML/Template/PHPLIB/Tool.php
+++ b/HTML/Template/PHPLIB/Tool.php
@@ -2,7 +2,7 @@
 /**
  * Additional tools for HTML_Template_PHPLIB
  *
- * PHP Versions 4 and 5
+ * PHP Versions 4.x/5.x/7.0.x
  *
  * @category HTML
  * @package  HTML_Template_PHPLIB
@@ -28,11 +28,11 @@ class HTML_Template_PHPLIB_Tool
     *
     * @param array $args Cmdline arguments
     */
-    function HTML_Template_PHPLIB_Tool($args)
+    function __construct($args)
     {
         $strAction = $this->getAction($args);
         $this->{'do' . ucfirst($strAction)}($args);
-    }//function HTML_Template_PHPLIB_Tool($args)
+    }//function __construct($args)
 
 
 


### PR DESCRIPTION
http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors